### PR TITLE
Extract raise from loop

### DIFF
--- a/python/scriptsmenu/launchfornuke.py
+++ b/python/scriptsmenu/launchfornuke.py
@@ -8,7 +8,7 @@ def _nuke_main_window():
         if (obj.inherits('QMainWindow') and
                     obj.metaObject().className() == 'Foundry::UI::DockMainWindow'):
             return obj
-        raise RuntimeError('Could not find Nuke MainWindow instance')
+    raise RuntimeError('Could not find Nuke MainWindow instance')
 
 
 def _nuke_main_menubar():


### PR DESCRIPTION
if the main window is not found in the first loop it produces an error.